### PR TITLE
feature/Rename "About" menu nav option to "About us"

### DIFF
--- a/src/components/header/HeaderView.jsx
+++ b/src/components/header/HeaderView.jsx
@@ -16,7 +16,7 @@ function HeaderView() {
         <Menu.Item key="Map">Map</Menu.Item>
         <Menu.Item key="Rules">Rules</Menu.Item>
         <Menu.Item key="Apply">Apply</Menu.Item>
-        <Menu.Item key="About">About</Menu.Item>
+        <Menu.Item key="About">About us</Menu.Item>
       </Menu>
     </div>
   );

--- a/tests/components/__snapshots__/DigitalTerrainWebApp.test.jsx.snap
+++ b/tests/components/__snapshots__/DigitalTerrainWebApp.test.jsx.snap
@@ -219,7 +219,7 @@ exports[`DigitalTerrainWebApp should render a default view 1`] = `
             class="ant-menu-item ant-menu-item-only-child"
             role="menuitem"
           >
-            About
+            About us
           </li>
           <li
             class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"

--- a/tests/components/__snapshots__/DigitalTerrainWebContainer.test.jsx.snap
+++ b/tests/components/__snapshots__/DigitalTerrainWebContainer.test.jsx.snap
@@ -216,7 +216,7 @@ exports[`DigitalTerrainWebContainer renders a default component 1`] = `
           class="ant-menu-item ant-menu-item-only-child"
           role="menuitem"
         >
-          About
+          About us
         </li>
         <li
           class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"

--- a/tests/components/__snapshots__/DigitalTerrainWebView.test.jsx.snap
+++ b/tests/components/__snapshots__/DigitalTerrainWebView.test.jsx.snap
@@ -216,7 +216,7 @@ exports[`DigitalTerrainWebView renders a default view 1`] = `
           class="ant-menu-item ant-menu-item-only-child"
           role="menuitem"
         >
-          About
+          About us
         </li>
         <li
           class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"

--- a/tests/components/header/__snapshots__/HeaderContainer.test.jsx.snap
+++ b/tests/components/header/__snapshots__/HeaderContainer.test.jsx.snap
@@ -210,7 +210,7 @@ exports[`HeaderContainer renders a default view 1`] = `
       class="ant-menu-item ant-menu-item-only-child"
       role="menuitem"
     >
-      About
+      About us
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"

--- a/tests/components/header/__snapshots__/HeaderView.test.jsx.snap
+++ b/tests/components/header/__snapshots__/HeaderView.test.jsx.snap
@@ -210,7 +210,7 @@ exports[`HeaderView renders a default view 1`] = `
       class="ant-menu-item ant-menu-item-only-child"
       role="menuitem"
     >
-      About
+      About us
     </li>
     <li
       class="ant-menu-submenu ant-menu-submenu-horizontal ant-menu-overflowed-submenu"


### PR DESCRIPTION

## Description of changes
 Resolves the issue : https://github.com/20BBrown14/digital-terrain-mc-js/issues/14 - Rename "About" menu nav option to "About us"

## Why?
"About us" I think more exemplifies what will be on this page.

## How was this change tested?

## UI change? Screenshots
![image](https://user-images.githubusercontent.com/42392347/85214748-d7089280-b345-11ea-8488-98dd81cc8a70.png)

## Other Notes
